### PR TITLE
[FIX] Dont see own name in roles

### DIFF
--- a/src/init_round.py
+++ b/src/init_round.py
@@ -77,7 +77,11 @@ def distribute_roles(players, roles):
         got_role = player['role']['name']
         if got_role in list(visible_to_data.keys()):
             visible_to_data[got_role]['entities'].append(player['name'])
-    
+
+    for role in list(visible_to_data):
+        if len(visible_to_data[role]['entities']) == 0:
+            visible_to_data.pop(role)
+
     # add visibility of roles to player_data
     for index in range(len(players.keys())):
         player = players[list(players.keys())[index]]
@@ -87,7 +91,22 @@ def distribute_roles(players, roles):
                 if 'other_role_info' in player.keys():
                     player['other_role_info'].update({role: role_data})
                 else:
-                    player['other_role_info'] = {role: role_data}
+                    player['other_role_info'] = {role: copy.deepcopy(role_data)}
+
+    # remove self name and empty groups
+    for player in players:
+        if 'other_role_info' in players[player]:
+            print(players[player]['other_role_info'])
+
+            # iterate through role visibility until own name found
+            for role in players[player]['other_role_info']:
+                for tmp in players[player]['other_role_info'][role]['entities']:
+                    if tmp == players[player]['name']:
+                        players[player]['other_role_info'][role]['entities'].remove(players[player]['name'])
+                        break
+                else:
+                    continue
+                break
 
     log.info("Distributed roles")
     return players, visible_to_data

--- a/src/loading.py
+++ b/src/loading.py
@@ -63,7 +63,6 @@ def load_tasks():
     """Load task yaml files from static directory"""
 
     all_files = [f for f in listdir(PATH_YAML_TASK_DIR) if isfile(join(PATH_YAML_TASK_DIR, f))]
-    print(all_files)
     tmp = {}
     for file in all_files:
 
@@ -121,6 +120,10 @@ class RoleModel(Model):
     parent_role = StringType()
     amount = IntType(required=True)
     chance = IntType(default=100) # in percent
+
+    def validate_parent_role(self, data, value):
+        if data['parent_role'] is None:
+            data.pop('parent_role')
 
 class TaskModel(Model):
     id = StringType(required=True)


### PR DESCRIPTION
Motivation
  - see only other teammates, not own name at user page
  - fixes the problem of having no parent role and having it displayed at user page

Related:
  - fixes #12
  - resolves #10