### PR TITLE
[ BUG ] non-Imposter Killing roles get Kill Button

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -10,6 +10,7 @@ Sheriff:
   description: "Complete all tasks or vote all Imposters out. You can kill someone the same way the Imposters can."
   visible_to: []
   has_tasks: true
+  can_kill: true
   parent_role: Crewmate
   amount: 2
   chance: 100
@@ -37,6 +38,7 @@ Imposter:
     - Lawyer
     - Vampire
   has_tasks: false
+  can_kill: true
   amount: 1
   chance: 100
 Vampire:
@@ -47,6 +49,7 @@ Vampire:
     - Lawyer
     - Vampir
   has_tasks: false
+  can_kill: true
   parent_role: Imposter
   amount: 1
   chance: 100
@@ -55,5 +58,6 @@ Jackal:
   description: "You are a third Party in the Game! Kill everybody to win."
   visible_to: []
   has_tasks: false
+  can_kill: true
   amount: 1
   chance: 100

--- a/src/loading.py
+++ b/src/loading.py
@@ -117,6 +117,7 @@ class RoleModel(Model):
     description = StringType(required=True)
     visible_to = ListType(StringType, default=[])
     has_tasks = BooleanType(default=True)
+    can_kill = BooleanType(default=False)
     parent_role = StringType()
     amount = IntType(required=True)
     chance = IntType(default=100) # in percent

--- a/src/templates/player_info.html
+++ b/src/templates/player_info.html
@@ -51,7 +51,7 @@
 	<button onclick="document.location='../../tasks'">Zum Aufgabenstatus</button> 
 	<button onclick="document.location='../../players'">Zur Spielerübersicht</button> 
 
-	{% if data.role.name == "Imposter" %}
+	{% if data.role.can_kill == true %}
 		<button id="kill" class="ready">💀 Kill</button>
 		<label class="hidden toplabel" id="killcount" for="kill"></label>
 	{% endif %}


### PR DESCRIPTION
Motivation
  - bug introduced to check on specific role
  - let anyone with killing abilities use the button

How:
  - introduced new characteristic to role: can_kill (boolean)
  - give all killing roles a button based on can_kill attribute

Related:
  - fixes #14