### PR TITLE
Prevent upload of generated qr_codes folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Generated files/folders
+qr_codes/


### PR DESCRIPTION
I added this to prevent the commit of the qr_codes folder generated when script `init.sh` is run.